### PR TITLE
Bumped PyQt version in requirements.txt up to 5.15.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy
 pyserial==3.5
 matplotlib==3.2.1
 pyqtgraph==0.11.0
-PyQt5==5.14
+PyQt5==5.15.2
 h5py
 Flask
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.19.3
 scipy
 pyserial==3.5
 matplotlib==3.2.1
-pyqtgraph==0.11.0
+pyqtgraph==0.11.1
 PyQt5==5.15.2
 h5py
 Flask


### PR DESCRIPTION
Addressing issue #67.
As the title says, bumped the PyQt5 version up to 5.15.2.
Work on macOS Big Sur, might be useful to test on other systems as well. 
Has been tested with Python 3.7.0 in a Conda environment. 
System: 13 inch 2020 MacBook Pro running macOS Big Sur 11.2
