### PR TITLE
Fix: Presence Detector Validation Error with Cached Configuration

### DIFF
--- a/src/acconeer/exptool/a121/algo/presence/_subsweep_utils.py
+++ b/src/acconeer/exptool/a121/algo/presence/_subsweep_utils.py
@@ -118,6 +118,11 @@ def _get_profile_subsweeps(
             curr_point += step * APPROX_BASE_STEP_LENGTH_M
             n_points_in_subsweep += 1
         curr_point_ind = int(round(curr_point / APPROX_BASE_STEP_LENGTH_M))
+        
+        # Ensure at least 1 point to prevent validation error
+        if n_points_in_subsweep == 0:
+            n_points_in_subsweep = 1
+            
         subsweeps_configs.append(
             a121.SubsweepConfig(
                 profile=profile,


### PR DESCRIPTION
## Fix: Presence Detector Validation Error with Cached Configuration

**Problem**: When the presence detector plugin loads cached configuration with `start_m=0.0`, `end_m=0.31`, and `automatic_subsweeps=True`, the `_get_profile_subsweeps` function creates a subsweep with `num_points=0`, which fails validation.

**Root Cause**: In `_get_profile_subsweeps` function, when the while loop doesn't execute (when `curr_point >= cut_point` initially), `n_points_in_subsweep` remains 0, causing the validation error.

**Solution**: Add a check to ensure `n_points_in_subsweep` is always at least 1 before creating the `SubsweepConfig`.

**Changes**:
- File: `src/acconeer/exptool/a121/algo/presence/_subsweep_utils.py`
- Function: `_get_profile_subsweeps`
- Lines: 119-121 (add check before creating SubsweepConfig)

```python
# Ensure at least 1 point to prevent validation error
if n_points_in_subsweep == 0:
    n_points_in_subsweep = 1
```

**Testing**: 
- Reproduced the bug with cached configuration and verified the fix prevents the validation error
- Confirmed that purging cache (`python -m acconeer.exptool.app --purge-cache`) also resolves the issue as a workaround

**Impact**: High priority - prevents users from using Presence Detector plugin when cached configuration contains problematic parameters.

**Workaround**: Users can resolve this issue by purging the cache, but this fix prevents it from occurring in the first place.