### PR TITLE
fix: incorrect re.sub argument and docutils deprecation warning

### DIFF
--- a/src/acconeer/exptool/_structs/qtpidgets.py
+++ b/src/acconeer/exptool/_structs/qtpidgets.py
@@ -49,8 +49,8 @@ def rst_to_html(s):
 
     from docutils.core import publish_parts
 
-    s = re.sub(r":ref:`([\s\S]+?)\s*<([\s\S]+)>`", r"\1", s, re.MULTILINE)
-    parts = publish_parts(s, writer_name="html")
+    s = re.sub(r":ref:`([\s\S]+?)\s*<([\s\S]+)>`", r"\1", s, flags=re.MULTILINE)
+    parts = publish_parts(s, writer="html")
     return parts["body"]
 
 


### PR DESCRIPTION
This fixes two issues in `rst_to_html` in `qtwidgets.py`:

- `re.sub` now passes `re.MULTILINE` as `flags`, not as the `count` argument with a value of `8`
- `docutils.publish_parts` now uses `writer="html"` instead of the deprecated `writer_name`

This removes warning noise from the CLI output shown when starting the tool.